### PR TITLE
Fix mobile UI rendering

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -10,6 +10,13 @@ img {
   max-width: none;
 }
 
+@media (max-width: $on-palm) {
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
 em img {
   max-width: 100%;
   margin-left: 0;

--- a/_sass/_people.scss
+++ b/_sass/_people.scss
@@ -61,3 +61,9 @@
         h1, p { color: inherit; }
     }
 }
+
+@media (max-width: $on-palm) {
+    .person {
+        width: 50%;
+    }
+}

--- a/_sass/_people.scss
+++ b/_sass/_people.scss
@@ -51,3 +51,13 @@
         }
     }
 }
+
+@media (hover: none) {
+    .person .thumbnail a span {
+        display: block;
+        position: static;
+        background: none;
+        padding: $space-1 0;
+        h1, p { color: inherit; }
+    }
+}

--- a/_sass/_projects.scss
+++ b/_sass/_projects.scss
@@ -51,3 +51,19 @@
         }
     }
 }
+
+@media (hover: none) {
+    .project .thumbnail a span {
+        display: block;
+        position: static;
+        background: none;
+        padding: $space-1 0;
+        h1, p { color: inherit; }
+    }
+}
+
+@media (max-width: $on-palm) {
+    .project {
+        width: 50%;
+    }
+}


### PR DESCRIPTION
This commit fixes three issues:

- no hover available on mobile, so names don't appear 
- images mo longer cause horizontal overflow
- tiles are at 50% instead of 33%, so they're mich less cramped